### PR TITLE
Add basic Next.js login with Prisma and Bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="mysql://user:password@localhost:3306/mydb"
+JWT_SECRET="supersecret"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # SDNPG
+
+Aplicación web construida con [Next.js](https://nextjs.org/) y [Prisma](https://www.prisma.io/) sobre MySQL.
+
+## Características
+
+- Login con usuario por defecto `admin`/`admin`.
+- Autenticación basada en JWT almacenado en cookie HTTP-only.
+- Dashboard general accesible solo para usuarios autenticados.
+- Estilos con [Bootstrap 5](https://getbootstrap.com/).
+
+## Configuración
+
+1. Copiar `.env.example` a `.env` y ajustar `DATABASE_URL` y `JWT_SECRET`.
+2. Ejecutar las migraciones y generar el cliente de Prisma:
+   ```bash
+   npx prisma migrate dev
+   ```
+3. Sembrar el usuario administrador:
+   ```bash
+   npm run seed
+   ```
+4. Iniciar la aplicación:
+   ```bash
+   npm run dev
+   ```
+
+## Rutas
+
+- `/` formulario de login.
+- `/dashboard` panel general (protegido).
+

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "sdnpg",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "bootstrap": "^5.3.3",
+    "@prisma/client": "^5.15.0",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "cookie": "^0.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "ts-node": "^10.9.2",
+    "prisma": "^5.15.0",
+    "eslint": "8.55.0",
+    "eslint-config-next": "14.2.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../lib/prisma';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { serialize } from 'cookie';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+  const { username, password } = req.body;
+  const user = await prisma.user.findUnique({ where: { username } });
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+  res.setHeader('Set-Cookie', serialize('token', token, { path: '/', httpOnly: true }));
+  return res.status(200).json({ message: 'ok' });
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,28 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default function Dashboard() {
+  return (
+    <div className="container mt-5">
+      <h1>Dashboard</h1>
+      <p>Bienvenido al panel general.</p>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    return { props: {} };
+  } catch {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      router.push('/dashboard');
+    } else {
+      const data = await res.json();
+      setError(data.message || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: '400px' }}>
+      <h1 className="mb-4">Login</h1>
+      <form onSubmit={handleSubmit}>
+        {error && <div className="alert alert-danger">{error}</div>}
+        <div className="mb-3">
+          <label className="form-label">Username</label>
+          <input
+            type="text"
+            className="form-control"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input
+            type="password"
+            className="form-control"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </div>
+        <button type="submit" className="btn btn-primary w-100">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,16 @@
+// This Prisma schema uses MySQL database
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id       Int    @id @default(autoincrement())
+  username String @unique
+  password String
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const hashed = await bcrypt.hash('admin', 10);
+  await prisma.user.upsert({
+    where: { username: 'admin' },
+    update: {},
+    create: { username: 'admin', password: hashed },
+  });
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node", "jest"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with Prisma ORM and MySQL configuration
- add login page, API route, and protected dashboard using JWT cookie auth
- seed default admin user and document setup

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3d6e2d2c8322ac1fab5af8ffec03