### PR TITLE
Add user roles and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Aplicación web construida con [Next.js](https://nextjs.org/) y [Prisma](https:/
 
 ## Características
 
-- Login con usuario por defecto `admin`/`admin`.
+- Usuarios con roles `ADMIN` y `OPERATOR`.
+- Login con credenciales por defecto `admin`/`admin` y `operator`/`operator`.
 - Autenticación basada en JWT almacenado en cookie HTTP-only.
 - Dashboard general accesible solo para usuarios autenticados.
 - Estilos con [Bootstrap 5](https://getbootstrap.com/).
@@ -12,15 +13,19 @@ Aplicación web construida con [Next.js](https://nextjs.org/) y [Prisma](https:/
 ## Configuración
 
 1. Copiar `.env.example` a `.env` y ajustar `DATABASE_URL` y `JWT_SECRET`.
-2. Ejecutar las migraciones y generar el cliente de Prisma:
+2. Instalar dependencias:
    ```bash
-   npx prisma migrate dev
+   npm install
    ```
-3. Sembrar el usuario administrador:
+3. Crear las tablas de la base de datos:
+   ```bash
+   npx prisma db push
+   ```
+4. Sembrar usuarios iniciales (administrador y operador):
    ```bash
    npm run seed
    ```
-4. Iniciar la aplicación:
+5. Iniciar la aplicación en modo desarrollo:
    ```bash
    npm run dev
    ```

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -17,7 +17,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!valid) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
-  const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+  const token = jwt.sign(
+    { userId: user.id, role: user.role },
+    process.env.JWT_SECRET || 'secret',
+    { expiresIn: '1h' }
+  );
   res.setHeader('Set-Cookie', serialize('token', token, { path: '/', httpOnly: true }));
   return res.status(200).json({ message: 'ok' });
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,14 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  ADMIN
+  OPERATOR
+}
+
 model User {
   id       Int    @id @default(autoincrement())
   username String @unique
   password String
+  role     Role   @default(ADMIN)
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,11 +4,19 @@ import bcrypt from 'bcryptjs';
 const prisma = new PrismaClient();
 
 async function main() {
-  const hashed = await bcrypt.hash('admin', 10);
+  const adminHashed = await bcrypt.hash('admin', 10);
+  const operatorHashed = await bcrypt.hash('operator', 10);
+
   await prisma.user.upsert({
     where: { username: 'admin' },
     update: {},
-    create: { username: 'admin', password: hashed },
+    create: { username: 'admin', password: adminHashed, role: 'ADMIN' },
+  });
+
+  await prisma.user.upsert({
+    where: { username: 'operator' },
+    update: {},
+    create: { username: 'operator', password: operatorHashed, role: 'OPERATOR' },
   });
 }
 


### PR DESCRIPTION
## Summary
- add Role enum and seed admin and operator users
- include role in JWT token
- document setup steps for Prisma and dev server

## Testing
- `npm run lint` (fails: missing @types/react, 403)


------
https://chatgpt.com/codex/tasks/task_e_68a0a0603d7c8322a3002e950892db41