### PR TITLE
Add admin sidebar and management CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import { useState } from 'react';
+
+interface SidebarProps {
+  role: string;
+}
+
+export default function Sidebar({ role }: SidebarProps) {
+  const [showAdmin, setShowAdmin] = useState(false);
+
+  const handleLogout = async () => {
+    await fetch('/api/logout');
+    window.location.href = '/';
+  };
+
+  return (
+    <div className="d-flex flex-column bg-light p-3" style={{ width: '250px', minHeight: '100vh' }}>
+      {role === 'ADMIN' && (
+        <>
+          <button
+            className="btn btn-link text-start"
+            onClick={() => setShowAdmin(!showAdmin)}
+          >
+            &#9881; Opciones
+          </button>
+          {showAdmin && (
+            <div className="ms-3 d-flex flex-column">
+              <Link className="btn btn-link text-start" href="/users">
+                Gestionar Usuarios
+              </Link>
+              <Link className="btn btn-link text-start" href="/passwords">
+                Gestionar Contraseñas
+              </Link>
+            </div>
+          )}
+        </>
+      )}
+      <div className="mt-auto">
+        <button className="btn btn-danger w-100" onClick={handleLogout}>
+          Logout
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { serialize } from 'cookie';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader(
+    'Set-Cookie',
+    serialize('token', '', { path: '/', httpOnly: true, maxAge: -1 })
+  );
+  res.status(200).json({ message: 'logged out' });
+}

--- a/pages/api/passwords/[id].ts
+++ b/pages/api/passwords/[id].ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'PUT') {
+    const { username, password, description } = req.body;
+    const entry = await prisma.credential.update({
+      where: { id: Number(id) },
+      data: { username, password, description },
+    });
+    return res.status(200).json(entry);
+  }
+  if (req.method === 'DELETE') {
+    await prisma.credential.delete({ where: { id: Number(id) } });
+    return res.status(204).end();
+  }
+  res.setHeader('Allow', 'PUT,DELETE');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/passwords/index.ts
+++ b/pages/api/passwords/index.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const entries = await prisma.credential.findMany();
+    return res.status(200).json(entries);
+  }
+  if (req.method === 'POST') {
+    const { username, password, description } = req.body;
+    const entry = await prisma.credential.create({
+      data: { username, password, description },
+    });
+    return res.status(201).json(entry);
+  }
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/users/[id].ts
+++ b/pages/api/users/[id].ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import bcrypt from 'bcryptjs';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'PUT') {
+    const { username, password, role } = req.body;
+    const data: any = { username, role };
+    if (password) {
+      data.password = await bcrypt.hash(password, 10);
+    }
+    const user = await prisma.user.update({
+      where: { id: Number(id) },
+      data,
+    });
+    return res.status(200).json(user);
+  }
+  if (req.method === 'DELETE') {
+    await prisma.user.delete({ where: { id: Number(id) } });
+    return res.status(204).end();
+  }
+  res.setHeader('Allow', 'PUT,DELETE');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import bcrypt from 'bcryptjs';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const users = await prisma.user.findMany();
+    return res.status(200).json(users);
+  }
+  if (req.method === 'POST') {
+    const { username, password, role } = req.body;
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: { username, password: hashed, role },
+    });
+    return res.status(201).json(user);
+  }
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,12 +1,20 @@
 import { GetServerSideProps } from 'next';
 import { parse } from 'cookie';
 import jwt from 'jsonwebtoken';
+import Sidebar from '../components/Sidebar';
 
-export default function Dashboard() {
+interface DashboardProps {
+  role: string;
+}
+
+export default function Dashboard({ role }: DashboardProps) {
   return (
-    <div className="container mt-5">
-      <h1>Dashboard</h1>
-      <p>Bienvenido al panel general.</p>
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h1>Dashboard</h1>
+        <p>Bienvenido al panel general.</p>
+      </div>
     </div>
   );
 }
@@ -15,8 +23,8 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   const cookies = parse(req.headers.cookie || '');
   const token = cookies.token || '';
   try {
-    jwt.verify(token, process.env.JWT_SECRET || 'secret');
-    return { props: {} };
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
   } catch {
     return {
       redirect: {

--- a/pages/passwords.tsx
+++ b/pages/passwords.tsx
@@ -1,0 +1,149 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../components/Sidebar';
+
+interface Entry {
+  id: number;
+  username: string;
+  password: string;
+  description: string;
+}
+
+export default function Passwords({ role }: { role: string }) {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [description, setDescription] = useState('');
+
+  const fetchEntries = async () => {
+    const res = await fetch('/api/passwords');
+    const data = await res.json();
+    setEntries(data);
+  };
+
+  useEffect(() => {
+    fetchEntries();
+  }, []);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/passwords', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password, description }),
+    });
+    setUsername('');
+    setPassword('');
+    setDescription('');
+    fetchEntries();
+  };
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/api/passwords/${id}`, { method: 'DELETE' });
+    fetchEntries();
+  };
+
+  const handleEdit = async (e: Entry) => {
+    const newUsername = prompt('Usuario', e.username) || e.username;
+    const newPassword = prompt('Contraseña', e.password) || e.password;
+    const newDescription = prompt('Descripción', e.description) || e.description;
+    await fetch(`/api/passwords/${e.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: newUsername, password: newPassword, description: newDescription }),
+    });
+    fetchEntries();
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Contraseñas</h2>
+        <form className="mb-3" onSubmit={handleAdd}>
+          <div className="mb-2">
+            <input
+              className="form-control"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              placeholder="Usuario"
+              required
+            />
+          </div>
+          <div className="mb-2">
+            <input
+              className="form-control"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="Contraseña"
+              required
+            />
+          </div>
+          <div className="mb-2">
+            <input
+              className="form-control"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder="Descripción"
+              required
+            />
+          </div>
+          <button className="btn btn-primary" type="submit">
+            Agregar
+          </button>
+        </form>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Usuario</th>
+              <th>Contraseña</th>
+              <th>Descripción</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(e => (
+              <tr key={e.id}>
+                <td>{e.username}</td>
+                <td>{e.password}</td>
+                <td>{e.description}</td>
+                <td>
+                  <button
+                    className="btn btn-sm btn-secondary me-2"
+                    onClick={() => handleEdit(e)}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    className="btn btn-sm btn-danger"
+                    onClick={() => handleDelete(e.id)}
+                  >
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return { redirect: { destination: '/dashboard', permanent: false } };
+    }
+    return { props: { role: payload.role } };
+  } catch {
+    return {
+      redirect: { destination: '/', permanent: false },
+    };
+  }
+};

--- a/pages/users.tsx
+++ b/pages/users.tsx
@@ -1,0 +1,148 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../components/Sidebar';
+
+interface User {
+  id: number;
+  username: string;
+  role: string;
+}
+
+export default function Users({ role }: { role: string }) {
+  const [users, setUsers] = useState<User[]>([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [userRole, setUserRole] = useState('OPERATOR');
+
+  const fetchUsers = async () => {
+    const res = await fetch('/api/users');
+    const data = await res.json();
+    setUsers(data);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password, role: userRole }),
+    });
+    setUsername('');
+    setPassword('');
+    setUserRole('OPERATOR');
+    fetchUsers();
+  };
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/api/users/${id}`, { method: 'DELETE' });
+    fetchUsers();
+  };
+
+  const handleEdit = async (u: User) => {
+    const newUsername = prompt('Nuevo usuario', u.username) || u.username;
+    const newPassword = prompt('Nueva contraseña (dejar vacío para mantener)', '');
+    const newRole = prompt('Rol (ADMIN u OPERATOR)', u.role) || u.role;
+    await fetch(`/api/users/${u.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: newUsername, password: newPassword, role: newRole }),
+    });
+    fetchUsers();
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Usuarios</h2>
+        <form className="mb-3" onSubmit={handleAdd}>
+          <div className="mb-2">
+            <input
+              className="form-control"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              placeholder="Usuario"
+              required
+            />
+          </div>
+          <div className="mb-2">
+            <input
+              type="password"
+              className="form-control"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="Contraseña"
+              required
+            />
+          </div>
+          <div className="mb-2">
+            <select
+              className="form-select"
+              value={userRole}
+              onChange={e => setUserRole(e.target.value)}
+            >
+              <option value="ADMIN">ADMIN</option>
+              <option value="OPERATOR">OPERATOR</option>
+            </select>
+          </div>
+          <button className="btn btn-primary" type="submit">
+            Agregar
+          </button>
+        </form>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Usuario</th>
+              <th>Rol</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(u => (
+              <tr key={u.id}>
+                <td>{u.username}</td>
+                <td>{u.role}</td>
+                <td>
+                  <button
+                    className="btn btn-sm btn-secondary me-2"
+                    onClick={() => handleEdit(u)}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    className="btn btn-sm btn-danger"
+                    onClick={() => handleDelete(u.id)}
+                  >
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return { redirect: { destination: '/dashboard', permanent: false } };
+    }
+    return { props: { role: payload.role } };
+  } catch {
+    return {
+      redirect: { destination: '/', permanent: false },
+    };
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,3 +20,10 @@ model User {
   password String
   role     Role   @default(ADMIN)
 }
+
+model Credential {
+  id          Int    @id @default(autoincrement())
+  username    String
+  password    String
+  description String
+}


### PR DESCRIPTION
## Summary
- add sidebar with admin-only options and logout
- implement user and password management pages with CRUD operations
- extend Prisma schema with Credential model and new API routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to install required TypeScript dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68a0a83658f08322b1281fe8cb3f7474