### PR TITLE
Add inventory menu and site CRUD with improved editing

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -7,6 +7,7 @@ interface SidebarProps {
 
 export default function Sidebar({ role }: SidebarProps) {
   const [showAdmin, setShowAdmin] = useState(false);
+  const [showInventory, setShowInventory] = useState(false);
 
   const handleLogout = async () => {
     await fetch('/api/logout');
@@ -15,27 +16,34 @@ export default function Sidebar({ role }: SidebarProps) {
 
   return (
     <div className="d-flex flex-column bg-light p-3" style={{ width: '250px', minHeight: '100vh' }}>
+      <button className="btn btn-link text-start" onClick={() => setShowInventory(!showInventory)}>
+        Inventario
+      </button>
+      {showInventory && (
+        <div className="ms-3 d-flex flex-column">
+          <Link className="btn btn-link text-start" href="/equipos">Equipos</Link>
+          <Link className="btn btn-link text-start" href="/sites">Sitios</Link>
+        </div>
+      )}
+
       {role === 'ADMIN' && (
         <>
           <button
-            className="btn btn-link text-start"
+            className="btn btn-link text-start mt-3"
             onClick={() => setShowAdmin(!showAdmin)}
           >
-            &#9881; Opciones
+            &#9881; Administración
           </button>
           {showAdmin && (
             <div className="ms-3 d-flex flex-column">
-              <Link className="btn btn-link text-start" href="/users">
-                Gestionar Usuarios
-              </Link>
-              <Link className="btn btn-link text-start" href="/passwords">
-                Gestionar Contraseñas
-              </Link>
+              <Link className="btn btn-link text-start" href="/users">Gestionar Usuarios</Link>
+              <Link className="btn btn-link text-start" href="/passwords">Gestionar Contraseñas</Link>
             </div>
           )}
         </>
       )}
-      <div className="mt-auto">
+
+      <div className="mt-auto pt-3">
         <button className="btn btn-danger w-100" onClick={handleLogout}>
           Logout
         </button>

--- a/pages/api/passwords/[id].ts
+++ b/pages/api/passwords/[id].ts
@@ -16,6 +16,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(401).json({ message: 'Unauthorized' });
   }
 
+  if (req.method === 'GET') {
+    const entry = await prisma.credential.findUnique({ where: { id: Number(id) } });
+    return res.status(200).json(entry);
+  }
+
   if (req.method === 'PUT') {
     const { username, password, description } = req.body;
     const entry = await prisma.credential.update({

--- a/pages/api/sites/[id].ts
+++ b/pages/api/sites/[id].ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import prisma from '../../../lib/prisma';
-import bcrypt from 'bcryptjs';
 import { parse } from 'cookie';
 import jwt from 'jsonwebtoken';
 
@@ -9,33 +8,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const cookies = parse(req.headers.cookie || '');
   const token = cookies.token || '';
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
-    if (payload.role !== 'ADMIN') {
-      return res.status(403).json({ message: 'Forbidden' });
-    }
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
   } catch {
     return res.status(401).json({ message: 'Unauthorized' });
   }
 
   if (req.method === 'GET') {
-    const user = await prisma.user.findUnique({ where: { id: Number(id) } });
-    return res.status(200).json(user);
+    const site = await prisma.site.findUnique({ where: { id: Number(id) } });
+    return res.status(200).json(site);
   }
 
   if (req.method === 'PUT') {
-    const { username, password, role } = req.body;
-    const data: any = { username, role };
-    if (password) {
-      data.password = await bcrypt.hash(password, 10);
-    }
-    const user = await prisma.user.update({
+    const { nombre, clave, ubicacion, zona, direccion } = req.body;
+    const site = await prisma.site.update({
       where: { id: Number(id) },
-      data,
+      data: { nombre, clave, ubicacion, zona, direccion },
     });
-    return res.status(200).json(user);
+    return res.status(200).json(site);
   }
   if (req.method === 'DELETE') {
-    await prisma.user.delete({ where: { id: Number(id) } });
+    await prisma.site.delete({ where: { id: Number(id) } });
     return res.status(204).end();
   }
   res.setHeader('Allow', 'PUT,DELETE');

--- a/pages/api/sites/index.ts
+++ b/pages/api/sites/index.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const sites = await prisma.site.findMany();
+    return res.status(200).json(sites);
+  }
+  if (req.method === 'POST') {
+    const { nombre, clave, ubicacion, zona, direccion } = req.body;
+    const site = await prisma.site.create({
+      data: { nombre, clave, ubicacion, zona, direccion },
+    });
+    return res.status(201).json(site);
+  }
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/equipos.tsx
+++ b/pages/equipos.tsx
@@ -1,0 +1,27 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import Sidebar from '../components/Sidebar';
+
+export default function Equipos({ role }: { role: string }) {
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Equipos</h2>
+        <p>Página de gestión de equipos.</p>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/pages/passwords/[id].tsx
+++ b/pages/passwords/[id].tsx
@@ -1,0 +1,67 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+interface EntryForm {
+  username: string;
+  password: string;
+  description: string;
+}
+
+export default function EditPassword({ role }: { role: string }) {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState<EntryForm>({ username: '', password: '', description: '' });
+
+  useEffect(() => {
+    if (id) {
+      fetch(`/api/passwords/${id}`).then(r => r.json()).then(e => setForm(e));
+    }
+  }, [id]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/passwords/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    router.push('/passwords');
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Editar Contraseña</h2>
+        <form onSubmit={handleSubmit} className="mb-3">
+          <input className="form-control mb-2" name="username" value={form.username} onChange={handleChange} placeholder="Usuario" required />
+          <input className="form-control mb-2" name="password" value={form.password} onChange={handleChange} placeholder="Contraseña" required />
+          <input className="form-control mb-2" name="description" value={form.description} onChange={handleChange} placeholder="Descripción" required />
+          <button className="btn btn-primary" type="submit">Guardar</button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return { redirect: { destination: '/dashboard', permanent: false } };
+    }
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/pages/sites/[id].tsx
+++ b/pages/sites/[id].tsx
@@ -1,0 +1,60 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+export default function EditSite({ role }: { role: string }) {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState({ nombre: '', clave: '', ubicacion: '', zona: '', direccion: '' });
+
+  useEffect(() => {
+    if (id) {
+      fetch(`/api/sites/${id}`).then(r => r.json()).then(setForm);
+    }
+  }, [id]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/sites/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    router.push('/sites');
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Editar Sitio</h2>
+        <form onSubmit={handleSubmit} className="mb-3">
+          <input className="form-control mb-2" name="nombre" value={form.nombre} onChange={handleChange} placeholder="Nombre" required />
+          <input className="form-control mb-2" name="clave" value={form.clave} onChange={handleChange} placeholder="Clave" required />
+          <input className="form-control mb-2" name="ubicacion" value={form.ubicacion} onChange={handleChange} placeholder="Ubicación" required />
+          <input className="form-control mb-2" name="zona" value={form.zona} onChange={handleChange} placeholder="Zona" required />
+          <input className="form-control mb-2" name="direccion" value={form.direccion} onChange={handleChange} placeholder="Dirección" required />
+          <button className="btn btn-primary" type="submit">Guardar</button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/pages/sites/index.tsx
+++ b/pages/sites/index.tsx
@@ -1,0 +1,137 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+interface Site {
+  id: number;
+  nombre: string;
+  clave: string;
+  ubicacion: string;
+  zona: string;
+  direccion: string;
+}
+
+export default function Sites({ role }: { role: string }) {
+  const [sites, setSites] = useState<Site[]>([]);
+  const [form, setForm] = useState({ nombre: '', clave: '', ubicacion: '', zona: '', direccion: '' });
+  const [search, setSearch] = useState('');
+
+  const fetchSites = async () => {
+    const res = await fetch('/api/sites');
+    const data = await res.json();
+    setSites(data);
+  };
+
+  useEffect(() => {
+    fetchSites();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/sites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    setForm({ nombre: '', clave: '', ubicacion: '', zona: '', direccion: '' });
+    fetchSites();
+  };
+
+  const handleDelete = async (id: number) => {
+    await fetch(`/api/sites/${id}`, { method: 'DELETE' });
+    fetchSites();
+  };
+
+  const handleEdit = (s: Site) => {
+    window.location.href = `/sites/${s.id}`;
+  };
+
+  const filtered = sites.filter(s =>
+    Object.values(s).some(v => v.toString().toLowerCase().includes(search.toLowerCase()))
+  );
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Sitios</h2>
+        <input
+          className="form-control mb-3"
+          placeholder="Buscar"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <form className="mb-3" onSubmit={handleAdd}>
+          <div className="row g-2">
+            <div className="col">
+              <input className="form-control" name="nombre" value={form.nombre} onChange={handleChange} placeholder="Nombre" required />
+            </div>
+            <div className="col">
+              <input className="form-control" name="clave" value={form.clave} onChange={handleChange} placeholder="Clave" required />
+            </div>
+          </div>
+          <div className="row g-2 mt-2">
+            <div className="col">
+              <input className="form-control" name="ubicacion" value={form.ubicacion} onChange={handleChange} placeholder="Ubicación" required />
+            </div>
+            <div className="col">
+              <input className="form-control" name="zona" value={form.zona} onChange={handleChange} placeholder="Zona" required />
+            </div>
+          </div>
+          <div className="mt-2">
+            <input className="form-control" name="direccion" value={form.direccion} onChange={handleChange} placeholder="Dirección" required />
+          </div>
+          <button className="btn btn-primary mt-2" type="submit">Agregar</button>
+        </form>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Nombre</th>
+              <th>Clave</th>
+              <th>Ubicación</th>
+              <th>Zona</th>
+              <th>Dirección</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(s => (
+              <tr key={s.id}>
+                <td>{s.nombre}</td>
+                <td>{s.clave}</td>
+                <td>{s.ubicacion}</td>
+                <td>{s.zona}</td>
+                <td>{s.direccion}</td>
+                <td>
+                  <button className="btn btn-sm btn-secondary me-2" onClick={() => handleEdit(s)}>
+                    Editar
+                  </button>
+                  <button className="btn btn-sm btn-danger" onClick={() => handleDelete(s.id)}>
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -1,0 +1,70 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+interface UserForm {
+  username: string;
+  password: string;
+  role: string;
+}
+
+export default function EditUser({ role }: { role: string }) {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState<UserForm>({ username: '', password: '', role: 'OPERATOR' });
+
+  useEffect(() => {
+    if (id) {
+      fetch(`/api/users/${id}`).then(r => r.json()).then(u => setForm({ username: u.username, password: '', role: u.role }));
+    }
+  }, [id]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/users/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    router.push('/users');
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Editar Usuario</h2>
+        <form onSubmit={handleSubmit} className="mb-3">
+          <input className="form-control mb-2" name="username" value={form.username} onChange={handleChange} placeholder="Usuario" required />
+          <input className="form-control mb-2" type="password" name="password" value={form.password} onChange={handleChange} placeholder="Contraseña (opcional)" />
+          <select className="form-select mb-2" name="role" value={form.role} onChange={handleChange}>
+            <option value="ADMIN">ADMIN</option>
+            <option value="OPERATOR">OPERATOR</option>
+          </select>
+          <button className="btn btn-primary" type="submit">Guardar</button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    if (payload.role !== 'ADMIN') {
+      return { redirect: { destination: '/dashboard', permanent: false } };
+    }
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,3 +27,12 @@ model Credential {
   password    String
   description String
 }
+
+model Site {
+  id        Int    @id @default(autoincrement())
+  nombre    String
+  clave     String
+  ubicacion String
+  zona      String
+  direccion String
+}


### PR DESCRIPTION
## Summary
- add inventory section to sidebar with Equipos and Sitios links
- implement Sitios CRUD with search filtering
- replace prompt-based edits with dedicated forms for users, passwords, and sites

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to install required TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ad0af62483228ae5b8ca229d8522