### PR TITLE
feat: add MikroTik backup API and view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+var

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -23,6 +23,7 @@ export default function Sidebar({ role }: SidebarProps) {
         <div className="ms-3 d-flex flex-column">
           <Link className="btn btn-link text-start" href="/equipos">Equipos</Link>
           <Link className="btn btn-link text-start" href="/sites">Sitios</Link>
+          <Link className="btn btn-link text-start" href="/backups">Backups</Link>
         </div>
       )}
 

--- a/pages/api/backup/index.ts
+++ b/pages/api/backup/index.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const backups = await prisma.backup.findMany({ orderBy: { createdAt: 'desc' } });
+    return res.status(200).json(backups);
+  }
+
+  res.setHeader('Allow', 'GET');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/backup/run.ts
+++ b/pages/api/backup/run.ts
@@ -1,0 +1,111 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { NodeSSH } from 'node-ssh';
+import prisma from '../../../lib/prisma';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { spawnSync } from 'child_process';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const { deviceId } = req.body as { deviceId?: number };
+  if (!deviceId) {
+    return res.status(400).json({ message: 'deviceId required' });
+  }
+
+  const equipment = await prisma.equipment.findUnique({
+    where: { id: Number(deviceId) },
+    include: { credential: true },
+  });
+
+  if (!equipment || !equipment.credential) {
+    return res.status(404).json({ message: 'Equipment or credential not found' });
+  }
+
+  const ssh = new NodeSSH();
+
+  try {
+    await ssh.connect({
+      host: equipment.ip,
+      username: equipment.credential.username,
+      password: equipment.credential.password,
+    });
+
+    const timestamp = Date.now();
+    const remoteExport = `config-${timestamp}.rsc`;
+    const remoteBackup = `backup-${timestamp}.backup`;
+
+    await ssh.execCommand(`/export file=${remoteExport}`);
+    await ssh.execCommand(`/system/backup/save name=${remoteBackup}`);
+
+    const baseDir = path.join(process.cwd(), 'var', 'data', 'backups', String(deviceId));
+    const exportDir = path.join(baseDir, 'export');
+    const binaryDir = path.join(baseDir, 'binary');
+    const diffDir = path.join(baseDir, 'diff');
+    fs.mkdirSync(exportDir, { recursive: true });
+    fs.mkdirSync(binaryDir, { recursive: true });
+    fs.mkdirSync(diffDir, { recursive: true });
+
+    const localExport = path.join(exportDir, remoteExport);
+    const localBinary = path.join(binaryDir, remoteBackup);
+
+    await ssh.getFile(localExport, remoteExport);
+    await ssh.getFile(localBinary, remoteBackup);
+
+    await ssh.execCommand(`/file/remove ${remoteExport}`);
+    await ssh.execCommand(`/file/remove ${remoteBackup}`);
+
+    const exportData = fs.readFileSync(localExport);
+    const binaryData = fs.readFileSync(localBinary);
+    const exportHash = crypto.createHash('sha256').update(exportData).digest('hex');
+    const binaryHash = crypto.createHash('sha256').update(binaryData).digest('hex');
+
+    let diffPath: string | null = null;
+    const rscFiles = fs.readdirSync(exportDir).filter((f) => f.endsWith('.rsc')).sort();
+    if (rscFiles.length > 1) {
+      const prev = path.join(exportDir, rscFiles[rscFiles.length - 2]);
+      const diffFile = `diff-${timestamp}.txt`;
+      diffPath = path.join(diffDir, diffFile);
+      const diff = spawnSync('diff', ['-u', prev, localExport], { encoding: 'utf-8' });
+      fs.writeFileSync(diffPath, diff.stdout);
+    }
+
+    const backup = await prisma.backup.create({
+      data: {
+        deviceId: Number(deviceId),
+        exportPath: localExport,
+        exportHash,
+        binaryPath: localBinary,
+        binaryHash,
+        diffPath,
+      },
+    });
+
+    return res.status(200).json({
+      backupId: backup.id,
+      exportPath: localExport,
+      binaryPath: localBinary,
+      diffPath,
+    });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ message: 'Backup failed' });
+  } finally {
+    ssh.dispose();
+  }
+}
+

--- a/pages/backups/index.tsx
+++ b/pages/backups/index.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+interface Backup {
+  id: number;
+  deviceId: number;
+  exportPath: string;
+  binaryPath: string;
+  diffPath?: string | null;
+  createdAt: string;
+}
+
+export default function Backups({ role }: { role: string }) {
+  const [backups, setBackups] = useState<Backup[]>([]);
+
+  useEffect(() => {
+    fetch('/api/backup').then(res => res.json()).then(setBackups);
+  }, []);
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Backups</h2>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Device</th>
+              <th>Export</th>
+              <th>Binary</th>
+              <th>Diff</th>
+              <th>Fecha</th>
+            </tr>
+          </thead>
+          <tbody>
+            {backups.map(b => (
+              <tr key={b.id}>
+                <td>{b.id}</td>
+                <td>{b.deviceId}</td>
+                <td>{b.exportPath}</td>
+                <td>{b.binaryPath}</td>
+                <td>{b.diffPath || ''}</td>
+                <td>{new Date(b.createdAt).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,3 +51,23 @@ model Equipment {
   credential   Credential? @relation(fields: [credentialId], references: [id])
   credentialId Int?
 }
+
+model Backup {
+  id         Int      @id @default(autoincrement())
+  deviceId   Int
+  exportPath String
+  exportHash String
+  binaryPath String
+  binaryHash String
+  diffPath   String?
+  createdAt  DateTime @default(now())
+}
+
+model Job {
+  id        Int      @id @default(autoincrement())
+  deviceId  Int
+  type      String
+  status    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
- add API route to run MikroTik configuration and system backups, compute hashes and diffs, and store metadata
- extend Prisma schema with Backup and Job tables
- ignore local backup artifacts
- add API endpoint and page to list stored backups
- link backups view in sidebar navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: could not install @types/react)
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68a1dfab08e083228030a561efdcd5cd