### PR TITLE
Use export verbose for backups and expose configuration

### DIFF
--- a/pages/api/backup/config.ts
+++ b/pages/api/backup/config.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import fs from 'fs';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).end('Unauthorized');
+  }
+
+  const filePath = req.query.path as string;
+  if (!filePath) {
+    return res.status(400).end('path required');
+  }
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    res.setHeader('Content-Type', 'text/plain');
+    return res.status(200).send(content);
+  } catch {
+    return res.status(404).end('Not found');
+  }
+}

--- a/pages/api/backup/run.ts
+++ b/pages/api/backup/run.ts
@@ -27,7 +27,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).json({
       backupId: backup.id,
       exportPath: backup.exportPath,
-      binaryPath: backup.binaryPath,
       diffPath: backup.diffPath,
     });
   } catch (e) {

--- a/pages/backups/[id].tsx
+++ b/pages/backups/[id].tsx
@@ -8,7 +8,6 @@ import Sidebar from '../../components/Sidebar';
 interface Backup {
   id: number;
   exportPath: string;
-  binaryPath: string;
   diffPath?: string | null;
   createdAt: string;
 }
@@ -55,8 +54,7 @@ export default function DeviceBackups({ role }: { role: string }) {
           <thead>
             <tr>
               <th>ID</th>
-              <th>Export</th>
-              <th>Binary</th>
+              <th>Configuración</th>
               <th>Diff</th>
               <th>Fecha</th>
             </tr>
@@ -65,11 +63,22 @@ export default function DeviceBackups({ role }: { role: string }) {
             {backups.map(b => (
               <tr key={b.id}>
                 <td>{b.id}</td>
-                <td>{b.exportPath}</td>
-                <td>{b.binaryPath}</td>
+                <td>
+                  <a
+                    href={`/api/backup/config?path=${encodeURIComponent(b.exportPath)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Ver configuración
+                  </a>
+                </td>
                 <td>
                   {b.diffPath ? (
-                    <a href={`/api/backup/diff?path=${encodeURIComponent(b.diffPath)}`} target="_blank" rel="noopener noreferrer">
+                    <a
+                      href={`/api/backup/diff?path=${encodeURIComponent(b.diffPath)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       Ver diferencias
                     </a>
                   ) : (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,8 +58,8 @@ model Backup {
   deviceId   Int
   exportPath String
   exportHash String
-  binaryPath String
-  binaryHash String
+  binaryPath String?
+  binaryHash String?
   diffPath   String?
   createdAt  DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- Capture device configuration via `/export verbose` and save locally with diff tracking
- Add endpoint to view stored configuration and show it in the backups page
- Scheduled job already triggers backups for all devices every 12 hours

## Testing
- `npm test` (Missing script: "test")
- `npm run lint` (Failed to install required TypeScript dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68a21cc4e5ac8322a3b2127c09551ad1