### PR TITLE
feat: add golden image management and scheduling

### DIFF
--- a/lib/goldenScheduler.ts
+++ b/lib/goldenScheduler.ts
@@ -1,0 +1,41 @@
+import prisma from './prisma';
+import { NodeSSH } from 'node-ssh';
+import path from 'path';
+
+const ONE_MINUTE = 60 * 1000;
+
+setInterval(async () => {
+  const jobs = await prisma.job.findMany({
+    where: {
+      type: 'upgrade',
+      status: 'pending',
+      scheduledAt: { lte: new Date() },
+    },
+    include: {
+      equipment: { include: { credential: true } },
+      goldenImage: true,
+    },
+  });
+
+  for (const job of jobs) {
+    const equipment = job.equipment;
+    const cred = equipment.credential;
+    const image = job.goldenImage;
+    if (!equipment || !cred || !image) {
+      await prisma.job.update({ where: { id: job.id }, data: { status: 'failed' } });
+      continue;
+    }
+    const ssh = new NodeSSH();
+    try {
+      await ssh.connect({ host: equipment.ip, username: cred.username, password: cred.password });
+      const localPath = path.join(process.cwd(), 'var', 'data', 'golden', image.model, image.filename);
+      await ssh.putFile(localPath, image.filename);
+      await prisma.job.update({ where: { id: job.id }, data: { status: 'completed' } });
+    } catch (e) {
+      console.error(e);
+      await prisma.job.update({ where: { id: job.id }, data: { status: 'failed' } });
+    } finally {
+      ssh.dispose();
+    }
+  }
+}, ONE_MINUTE);

--- a/pages/api/golden/index.ts
+++ b/pages/api/golden/index.ts
@@ -1,0 +1,66 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import '../../../lib/goldenScheduler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const images = await prisma.goldenImage.findMany();
+    return res.status(200).json(images);
+  }
+
+  if (req.method === 'POST') {
+    const { model, version, file, filename } = req.body;
+    if (!model || !version || !file || !filename) {
+      return res.status(400).json({ message: 'Missing fields' });
+    }
+
+    const buffer = Buffer.from(file, 'base64');
+    const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
+
+    const dir = path.join(process.cwd(), 'var', 'data', 'golden', model);
+    fs.mkdirSync(dir, { recursive: true });
+
+    const existing = await prisma.goldenImage.findUnique({ where: { model } });
+    if (existing) {
+      try {
+        fs.unlinkSync(path.join(dir, existing.filename));
+        fs.unlinkSync(path.join(dir, 'metadata.json'));
+      } catch {}
+      await prisma.goldenImage.delete({ where: { id: existing.id } });
+    }
+
+    const destName = filename;
+    const destPath = path.join(dir, destName);
+    fs.writeFileSync(destPath, buffer);
+
+    const metadata = {
+      model,
+      version,
+      filename: destName,
+      sha256,
+      uploadedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(path.join(dir, 'metadata.json'), JSON.stringify(metadata, null, 2));
+
+    const image = await prisma.goldenImage.create({
+      data: { model, version, filename: destName, sha256 },
+    });
+    return res.status(201).json(image);
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/golden/schedule.ts
+++ b/pages/api/golden/schedule.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import '../../../lib/goldenScheduler';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'POST') {
+    const { deviceId, goldenImageId, date } = req.body;
+    if (!deviceId || !goldenImageId || !date) {
+      return res.status(400).json({ message: 'Missing fields' });
+    }
+    const scheduledAt = new Date(date);
+    const job = await prisma.job.create({
+      data: {
+        deviceId: Number(deviceId),
+        type: 'upgrade',
+        status: 'pending',
+        scheduledAt,
+        goldenImageId: Number(goldenImageId),
+      },
+    });
+    return res.status(201).json(job);
+  }
+
+  res.setHeader('Allow', 'POST');
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/software/index.tsx
+++ b/pages/software/index.tsx
@@ -1,0 +1,202 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+import SearchBar from '../../components/SearchBar';
+
+interface Equipment {
+  id: number;
+  hostname: string;
+  ip: string;
+  chassis: string;
+  serial: string;
+  version: string;
+  type: string;
+}
+
+interface GoldenImage {
+  id: number;
+  model: string;
+  version: string;
+  filename: string;
+}
+
+export default function Software({ role }: { role: string }) {
+  const [equipos, setEquipos] = useState<Equipment[]>([]);
+  const [golden, setGolden] = useState<GoldenImage[]>([]);
+  const [currentModel, setCurrentModel] = useState('');
+  const [version, setVersion] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [scheduleId, setScheduleId] = useState<number | null>(null);
+  const [scheduleDate, setScheduleDate] = useState('');
+  const [search, setSearch] = useState('');
+
+  const fetchData = async () => {
+    const eq = await fetch('/api/equipos').then(r => r.json());
+    const gi = await fetch('/api/golden').then(r => r.json());
+    setEquipos(eq);
+    setGolden(gi);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const models = Array.from(new Set(equipos.map(e => e.chassis)));
+  const goldenMap: Record<string, GoldenImage> = {};
+  golden.forEach(g => (goldenMap[g.model] = g));
+
+  const filtered = equipos.filter(e =>
+    Object.values(e).some(v => v && v.toString().toLowerCase().includes(search.toLowerCase()))
+  );
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const buf = await file.arrayBuffer();
+    const base64 = Buffer.from(buf).toString('base64');
+    await fetch('/api/golden', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: currentModel, version, filename: file.name, file: base64 }),
+    });
+    setVersion('');
+    setFile(null);
+    fetchData();
+  };
+
+  const handleSchedule = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!scheduleId) return;
+    const model = equipos.find(eq => eq.id === scheduleId)?.chassis || '';
+    const g = goldenMap[model];
+    if (!g) return;
+    await fetch('/api/golden/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceId: scheduleId, goldenImageId: g.id, date: scheduleDate }),
+    });
+    setScheduleId(null);
+    setScheduleDate('');
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Software de equipos</h2>
+        <div className="d-flex flex-wrap gap-2 mb-3">
+          {models.map(m => (
+            <div key={m}>
+              <span className="me-2">{m}</span>
+              <button
+                className="btn btn-sm btn-secondary"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#uploadGolden"
+                onClick={() => setCurrentModel(m)}
+              >
+                Subir golden imagen
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <SearchBar value={search} onChange={setSearch} />
+        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Modelo</th>
+              <th>Golden</th>
+              <th>Equipo</th>
+              <th>Versión actual</th>
+              <th>Estado de versión</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(e => {
+              const g = goldenMap[e.chassis];
+              const match = g && e.version === g.version;
+              return (
+                <tr key={e.id}>
+                  <td>{e.chassis}</td>
+                  <td>{g?.version || '-'}</td>
+                  <td>{e.hostname}</td>
+                  <td>{e.version}</td>
+                  <td>
+                    {match ? (
+                      '✅'
+                    ) : (
+                      <button
+                        className="btn btn-sm btn-warning"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#scheduleJob"
+                        onClick={() => setScheduleId(e.id)}
+                      >
+                        Calendarizar
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="offcanvas offcanvas-end" tabIndex={-1} id="uploadGolden">
+        <div className="offcanvas-header">
+          <h5 className="offcanvas-title">Subir Golden - {currentModel}</h5>
+          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div className="offcanvas-body">
+          <form onSubmit={handleUpload}>
+            <div className="mb-2">
+              <input
+                className="form-control"
+                value={version}
+                onChange={e => setVersion(e.target.value)}
+                placeholder="Versión"
+                required
+              />
+            </div>
+            <div className="mb-2">
+              <input className="form-control" type="file" onChange={e => setFile(e.target.files?.[0] || null)} required />
+            </div>
+            <button className="btn btn-primary" type="submit">Guardar</button>
+          </form>
+        </div>
+      </div>
+      <div className="offcanvas offcanvas-end" tabIndex={-1} id="scheduleJob">
+        <div className="offcanvas-header">
+          <h5 className="offcanvas-title">Calendarizar</h5>
+          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div className="offcanvas-body">
+          <form onSubmit={handleSchedule}>
+            <div className="mb-2">
+              <input
+                type="datetime-local"
+                className="form-control"
+                value={scheduleDate}
+                onChange={e => setScheduleDate(e.target.value)}
+                required
+              />
+            </div>
+            <button className="btn btn-primary" type="submit">Guardar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Equipment {
   siteId       Int?
   credential   Credential? @relation(fields: [credentialId], references: [id])
   credentialId Int?
+  jobs         Job[]
 }
 
 model Backup {
@@ -69,6 +70,20 @@ model Job {
   deviceId  Int
   type      String
   status    String
+  scheduledAt DateTime?
+  goldenImageId Int?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  equipment   Equipment @relation(fields: [deviceId], references: [id])
+  goldenImage GoldenImage? @relation(fields: [goldenImageId], references: [id])
+}
+
+model GoldenImage {
+  id        Int      @id @default(autoincrement())
+  model     String   @unique
+  version   String
+  filename  String
+  sha256    String
+  uploadedAt DateTime @default(now())
+  jobs      Job[]
 }


### PR DESCRIPTION
## Summary
- add models for golden images and upgrade jobs
- implement API endpoints and scheduler for uploading and scheduling golden images
- create UI for managing equipment software and scheduling upgrades

## Testing
- `npm run lint` *(fails: Failed to install required TypeScript dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68a25307e5b88322b1501594e8152891