### PR TITLE
feat: add equipment software management

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -16,20 +16,20 @@ export default function Sidebar({ role }: SidebarProps) {
 
   return (
     <div
-      className="d-flex flex-column flex-shrink-0 p-3 bg-light"
+      className="d-flex flex-column flex-shrink-0 p-3 bg-dark text-white"
       style={{ width: '280px', minHeight: '100vh' }}
     >
       <Link
         href="/dashboard"
-        className="d-flex align-items-center mb-3 mb-md-0 me-md-auto link-dark text-decoration-none"
+        className="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none"
       >
         <span className="fs-4">SDNPG</span>
       </Link>
-      <hr />
+      <hr className="border-secondary" />
       <ul className="nav nav-pills flex-column mb-auto">
         <li className="nav-item">
           <button
-            className="nav-link text-start w-100 bg-transparent border-0"
+            className="nav-link text-start w-100 bg-transparent border-0 text-white"
             onClick={() => setShowInventory(!showInventory)}
           >
             Inventario
@@ -37,18 +37,23 @@ export default function Sidebar({ role }: SidebarProps) {
           {showInventory && (
             <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
               <li>
-                <Link href="/equipos" className="nav-link link-dark ms-3">
+                <Link href="/equipos" className="nav-link link-light ms-3">
                   Equipos
                 </Link>
               </li>
               <li>
-                <Link href="/sites" className="nav-link link-dark ms-3">
+                <Link href="/sites" className="nav-link link-light ms-3">
                   Sitios
                 </Link>
               </li>
               <li>
-                <Link href="/backups" className="nav-link link-dark ms-3">
+                <Link href="/backups" className="nav-link link-light ms-3">
                   Backups
+                </Link>
+              </li>
+              <li>
+                <Link href="/software" className="nav-link link-light ms-3">
+                  Actualizaciones
                 </Link>
               </li>
             </ul>
@@ -58,7 +63,7 @@ export default function Sidebar({ role }: SidebarProps) {
         {role === 'ADMIN' && (
           <li className="nav-item mt-3">
             <button
-              className="nav-link text-start w-100 bg-transparent border-0"
+              className="nav-link text-start w-100 bg-transparent border-0 text-white"
               onClick={() => setShowAdmin(!showAdmin)}
             >
               &#9881; Administración
@@ -66,12 +71,12 @@ export default function Sidebar({ role }: SidebarProps) {
             {showAdmin && (
               <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
                 <li>
-                  <Link href="/users" className="nav-link link-dark ms-3">
+                  <Link href="/users" className="nav-link link-light ms-3">
                     Gestionar Usuarios
                   </Link>
                 </li>
                 <li>
-                  <Link href="/passwords" className="nav-link link-dark ms-3">
+                  <Link href="/passwords" className="nav-link link-light ms-3">
                     Gestionar Contraseñas
                   </Link>
                 </li>
@@ -80,7 +85,7 @@ export default function Sidebar({ role }: SidebarProps) {
           </li>
         )}
       </ul>
-      <hr />
+      <hr className="border-secondary" />
       <button className="btn btn-danger w-100 mt-auto" onClick={handleLogout}>
         Logout
       </button>

--- a/pages/api/golden/index.ts
+++ b/pages/api/golden/index.ts
@@ -5,7 +5,6 @@ import jwt from 'jsonwebtoken';
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
-import '../../../lib/goldenScheduler';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const cookies = parse(req.headers.cookie || '');

--- a/pages/api/golden/schedule.ts
+++ b/pages/api/golden/schedule.ts
@@ -2,7 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import prisma from '../../../lib/prisma';
 import { parse } from 'cookie';
 import jwt from 'jsonwebtoken';
-import '../../../lib/goldenScheduler';
+import { NodeSSH } from 'node-ssh';
+import path from 'path';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const cookies = parse(req.headers.cookie || '');
@@ -18,17 +19,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!deviceId || !goldenImageId || !date) {
       return res.status(400).json({ message: 'Missing fields' });
     }
-    const scheduledAt = new Date(date);
-    const job = await prisma.job.create({
-      data: {
-        deviceId: Number(deviceId),
-        type: 'upgrade',
-        status: 'pending',
-        scheduledAt,
-        goldenImageId: Number(goldenImageId),
-      },
+
+    const equipment = await prisma.equipment.findUnique({
+      where: { id: Number(deviceId) },
+      include: { credential: true },
     });
-    return res.status(201).json(job);
+    const image = await prisma.goldenImage.findUnique({ where: { id: Number(goldenImageId) } });
+    if (!equipment || !equipment.credential || !image) {
+      return res.status(404).json({ message: 'Data not found' });
+    }
+
+    const ssh = new NodeSSH();
+    try {
+      await ssh.connect({
+        host: equipment.ip,
+        username: equipment.credential.username,
+        password: equipment.credential.password,
+      });
+      const localPath = path.join(process.cwd(), 'var', 'data', 'golden', image.model, image.filename);
+      await ssh.putFile(localPath, image.filename);
+      const d = new Date(date);
+      const months = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+      const formatted = `${months[d.getMonth()]}/${d.getDate()}/${d.getFullYear()}`;
+      await ssh.execCommand(`/system scheduler add name="reboot-programado" start-date=${formatted} start-time=02:30:00 on-event="/system reboot"`);
+    } catch (e) {
+      console.error(e);
+      return res.status(500).json({ message: 'SSH error' });
+    } finally {
+      ssh.dispose();
+    }
+
+    return res.status(201).json({ message: 'Scheduled' });
   }
 
   res.setHeader('Allow', 'POST');

--- a/pages/software/index.tsx
+++ b/pages/software/index.tsx
@@ -76,6 +76,7 @@ export default function Software({ role }: { role: string }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ deviceId: scheduleId, goldenImageId: g.id, date: scheduleDate }),
     });
+    fetchData();
     setScheduleId(null);
     setScheduleDate('');
   };
@@ -175,7 +176,7 @@ export default function Software({ role }: { role: string }) {
           <form onSubmit={handleSchedule}>
             <div className="mb-2">
               <input
-                type="datetime-local"
+                type="date"
                 className="form-control"
                 value={scheduleDate}
                 onChange={e => setScheduleDate(e.target.value)}


### PR DESCRIPTION
## Summary
- style sidebar like Cisco DNAC and add "Actualizaciones" link
- allow golden image scheduling to upload via SFTP and reboot on chosen date
- support local golden image storage with metadata and hash

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to install required TypeScript dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68a26d6d24888322b8ba7c9b988c5db7