### PR TITLE
feat: split software management and clean golden uploads

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarProps {
 export default function Sidebar({ role }: SidebarProps) {
   const [showAdmin, setShowAdmin] = useState(false);
   const [showInventory, setShowInventory] = useState(false);
+  const [showSoftware, setShowSoftware] = useState(false);
 
   const handleLogout = async () => {
     await fetch('/api/logout');
@@ -51,9 +52,27 @@ export default function Sidebar({ role }: SidebarProps) {
                   Backups
                 </Link>
               </li>
+            </ul>
+          )}
+        </li>
+
+        <li className="nav-item mt-3">
+          <button
+            className="nav-link text-start w-100 bg-transparent border-0 text-white"
+            onClick={() => setShowSoftware(!showSoftware)}
+          >
+            Software
+          </button>
+          {showSoftware && (
+            <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
               <li>
-                <Link href="/software" className="nav-link link-light ms-3">
-                  Actualizaciones
+                <Link href="/software/golden" className="nav-link link-light ms-3">
+                  Golden Images
+                </Link>
+              </li>
+              <li>
+                <Link href="/software/equipos" className="nav-link link-light ms-3">
+                  Equipos
                 </Link>
               </li>
             </ul>

--- a/pages/api/golden/index.ts
+++ b/pages/api/golden/index.ts
@@ -30,14 +30,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
 
     const dir = path.join(process.cwd(), 'var', 'data', 'golden', model);
+    fs.rmSync(dir, { recursive: true, force: true });
     fs.mkdirSync(dir, { recursive: true });
 
     const existing = await prisma.goldenImage.findUnique({ where: { model } });
     if (existing) {
-      try {
-        fs.unlinkSync(path.join(dir, existing.filename));
-        fs.unlinkSync(path.join(dir, 'metadata.json'));
-      } catch {}
       await prisma.goldenImage.delete({ where: { id: existing.id } });
     }
 

--- a/pages/software/equipos/index.tsx
+++ b/pages/software/equipos/index.tsx
@@ -2,32 +2,25 @@ import { GetServerSideProps } from 'next';
 import { parse } from 'cookie';
 import jwt from 'jsonwebtoken';
 import { useEffect, useState } from 'react';
-import Sidebar from '../../components/Sidebar';
-import SearchBar from '../../components/SearchBar';
+import Sidebar from '../../../components/Sidebar';
+import SearchBar from '../../../components/SearchBar';
 
 interface Equipment {
   id: number;
   hostname: string;
-  ip: string;
   chassis: string;
-  serial: string;
   version: string;
-  type: string;
 }
 
 interface GoldenImage {
   id: number;
   model: string;
   version: string;
-  filename: string;
 }
 
-export default function Software({ role }: { role: string }) {
+export default function SoftwareEquipos({ role }: { role: string }) {
   const [equipos, setEquipos] = useState<Equipment[]>([]);
   const [golden, setGolden] = useState<GoldenImage[]>([]);
-  const [currentModel, setCurrentModel] = useState('');
-  const [version, setVersion] = useState('');
-  const [file, setFile] = useState<File | null>(null);
   const [scheduleId, setScheduleId] = useState<number | null>(null);
   const [scheduleDate, setScheduleDate] = useState('');
   const [search, setSearch] = useState('');
@@ -43,27 +36,12 @@ export default function Software({ role }: { role: string }) {
     fetchData();
   }, []);
 
-  const models = Array.from(new Set(equipos.map(e => e.chassis)));
   const goldenMap: Record<string, GoldenImage> = {};
   golden.forEach(g => (goldenMap[g.model] = g));
 
   const filtered = equipos.filter(e =>
     Object.values(e).some(v => v && v.toString().toLowerCase().includes(search.toLowerCase()))
   );
-  const handleUpload = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!file) return;
-    const buf = await file.arrayBuffer();
-    const base64 = Buffer.from(buf).toString('base64');
-    await fetch('/api/golden', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: currentModel, version, filename: file.name, file: base64 }),
-    });
-    setVersion('');
-    setFile(null);
-    fetchData();
-  };
 
   const handleSchedule = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -85,22 +63,7 @@ export default function Software({ role }: { role: string }) {
     <div className="d-flex">
       <Sidebar role={role} />
       <div className="p-4 flex-grow-1">
-        <h2>Software de equipos</h2>
-        <div className="d-flex flex-wrap gap-2 mb-3">
-          {models.map(m => (
-            <div key={m}>
-              <span className="me-2">{m}</span>
-              <button
-                className="btn btn-sm btn-secondary"
-                data-bs-toggle="offcanvas"
-                data-bs-target="#uploadGolden"
-                onClick={() => setCurrentModel(m)}
-              >
-                Subir golden imagen
-              </button>
-            </div>
-          ))}
-        </div>
+        <h2>Equipos</h2>
         <div className="d-flex justify-content-between align-items-center mb-3">
           <SearchBar value={search} onChange={setSearch} />
         </div>
@@ -143,29 +106,6 @@ export default function Software({ role }: { role: string }) {
             })}
           </tbody>
         </table>
-      </div>
-      <div className="offcanvas offcanvas-end" tabIndex={-1} id="uploadGolden">
-        <div className="offcanvas-header">
-          <h5 className="offcanvas-title">Subir Golden - {currentModel}</h5>
-          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-        </div>
-        <div className="offcanvas-body">
-          <form onSubmit={handleUpload}>
-            <div className="mb-2">
-              <input
-                className="form-control"
-                value={version}
-                onChange={e => setVersion(e.target.value)}
-                placeholder="Versión"
-                required
-              />
-            </div>
-            <div className="mb-2">
-              <input className="form-control" type="file" onChange={e => setFile(e.target.files?.[0] || null)} required />
-            </div>
-            <button className="btn btn-primary" type="submit">Guardar</button>
-          </form>
-        </div>
       </div>
       <div className="offcanvas offcanvas-end" tabIndex={-1} id="scheduleJob">
         <div className="offcanvas-header">

--- a/pages/software/golden/index.tsx
+++ b/pages/software/golden/index.tsx
@@ -1,0 +1,113 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../../components/Sidebar';
+
+interface Equipment {
+  id: number;
+  chassis: string;
+}
+
+interface GoldenImage {
+  id: number;
+  model: string;
+  version: string;
+  filename: string;
+}
+
+export default function GoldenImages({ role }: { role: string }) {
+  const [equipos, setEquipos] = useState<Equipment[]>([]);
+  const [golden, setGolden] = useState<GoldenImage[]>([]);
+  const [currentModel, setCurrentModel] = useState('');
+  const [version, setVersion] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  const fetchData = async () => {
+    const eq = await fetch('/api/equipos').then(r => r.json());
+    const gi = await fetch('/api/golden').then(r => r.json());
+    setEquipos(eq);
+    setGolden(gi);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const models = Array.from(new Set(equipos.map(e => e.chassis)));
+  const goldenMap: Record<string, GoldenImage> = {};
+  golden.forEach(g => (goldenMap[g.model] = g));
+
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const buf = await file.arrayBuffer();
+    const base64 = Buffer.from(buf).toString('base64');
+    await fetch('/api/golden', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: currentModel, version, filename: file.name, file: base64 }),
+    });
+    setVersion('');
+    setFile(null);
+    fetchData();
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Golden Images</h2>
+        <div className="d-flex flex-wrap gap-2">
+          {models.map(m => (
+            <div key={m} className="mb-2">
+              <span className="me-2">{m} - {goldenMap[m]?.version || '-'}</span>
+              <button
+                className="btn btn-sm btn-secondary"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#uploadGolden"
+                onClick={() => setCurrentModel(m)}
+              >
+                Subir golden imagen
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="offcanvas offcanvas-end" tabIndex={-1} id="uploadGolden">
+        <div className="offcanvas-header">
+          <h5 className="offcanvas-title">Subir Golden - {currentModel}</h5>
+          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div className="offcanvas-body">
+          <form onSubmit={handleUpload}>
+            <div className="mb-2">
+              <input
+                className="form-control"
+                value={version}
+                onChange={e => setVersion(e.target.value)}
+                placeholder="Versión"
+                required
+              />
+            </div>
+            <div className="mb-2">
+              <input className="form-control" type="file" onChange={e => setFile(e.target.files?.[0] || null)} required />
+            </div>
+            <button className="btn btn-primary" type="submit">Guardar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};


### PR DESCRIPTION
## Summary
- add dedicated Software menu with Golden Images and Equipos subpages
- split software features into golden image upload and version validation pages
- wipe golden image directory before saving new upload

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to install required TypeScript dependencies: @types/react)


------
https://chatgpt.com/codex/tasks/task_e_68a28f871d3483228440e81b5d0ba610