### PR TITLE
Add golden images section to sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -53,7 +53,7 @@ export default function Sidebar({ role }: SidebarProps) {
               </li>
               <li>
                 <Link href="/software" className="nav-link link-light ms-3">
-                  Actualizaciones
+                  Golden Images y Actualizaciones
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- include link to Golden Images y Actualizaciones in sidebar menu

## Testing
- `npm run lint` *(fails: Failed to install required TypeScript dependencies: @types/react; attempted install but 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a292c9aaa48322869ac78c4c5c3bf1