### PR TITLE
feat: add software management sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 var
+.next

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarProps {
 export default function Sidebar({ role }: SidebarProps) {
   const [showAdmin, setShowAdmin] = useState(false);
   const [showInventory, setShowInventory] = useState(false);
+  const [showSoftware, setShowSoftware] = useState(false);
 
   const handleLogout = async () => {
     await fetch('/api/logout');
@@ -51,9 +52,27 @@ export default function Sidebar({ role }: SidebarProps) {
                   Backups
                 </Link>
               </li>
+            </ul>
+          )}
+        </li>
+
+        <li className="nav-item mt-3">
+          <button
+            className="nav-link text-start w-100 bg-transparent border-0 text-white"
+            onClick={() => setShowSoftware(!showSoftware)}
+          >
+            Gestión de software
+          </button>
+          {showSoftware && (
+            <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
               <li>
-                <Link href="/software" className="nav-link link-light ms-3">
-                  Golden Images y Actualizaciones
+                <Link href="/software/golden" className="nav-link link-light ms-3">
+                  Golden Image
+                </Link>
+              </li>
+              <li>
+                <Link href="/software/actualizaciones" className="nav-link link-light ms-3">
+                  Actualizaciones
                 </Link>
               </li>
             </ul>

--- a/pages/software/actualizaciones.tsx
+++ b/pages/software/actualizaciones.tsx
@@ -22,12 +22,9 @@ interface GoldenImage {
   filename: string;
 }
 
-export default function Software({ role }: { role: string }) {
+export default function Actualizaciones({ role }: { role: string }) {
   const [equipos, setEquipos] = useState<Equipment[]>([]);
   const [golden, setGolden] = useState<GoldenImage[]>([]);
-  const [currentModel, setCurrentModel] = useState('');
-  const [version, setVersion] = useState('');
-  const [file, setFile] = useState<File | null>(null);
   const [scheduleId, setScheduleId] = useState<number | null>(null);
   const [scheduleDate, setScheduleDate] = useState('');
   const [search, setSearch] = useState('');
@@ -43,27 +40,12 @@ export default function Software({ role }: { role: string }) {
     fetchData();
   }, []);
 
-  const models = Array.from(new Set(equipos.map(e => e.chassis)));
   const goldenMap: Record<string, GoldenImage> = {};
   golden.forEach(g => (goldenMap[g.model] = g));
 
   const filtered = equipos.filter(e =>
     Object.values(e).some(v => v && v.toString().toLowerCase().includes(search.toLowerCase()))
   );
-  const handleUpload = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!file) return;
-    const buf = await file.arrayBuffer();
-    const base64 = Buffer.from(buf).toString('base64');
-    await fetch('/api/golden', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: currentModel, version, filename: file.name, file: base64 }),
-    });
-    setVersion('');
-    setFile(null);
-    fetchData();
-  };
 
   const handleSchedule = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -85,22 +67,7 @@ export default function Software({ role }: { role: string }) {
     <div className="d-flex">
       <Sidebar role={role} />
       <div className="p-4 flex-grow-1">
-        <h2>Software de equipos</h2>
-        <div className="d-flex flex-wrap gap-2 mb-3">
-          {models.map(m => (
-            <div key={m}>
-              <span className="me-2">{m}</span>
-              <button
-                className="btn btn-sm btn-secondary"
-                data-bs-toggle="offcanvas"
-                data-bs-target="#uploadGolden"
-                onClick={() => setCurrentModel(m)}
-              >
-                Subir golden imagen
-              </button>
-            </div>
-          ))}
-        </div>
+        <h2>Actualizaciones</h2>
         <div className="d-flex justify-content-between align-items-center mb-3">
           <SearchBar value={search} onChange={setSearch} />
         </div>
@@ -119,7 +86,7 @@ export default function Software({ role }: { role: string }) {
               const g = goldenMap[e.chassis];
               const match = g && e.version === g.version;
               return (
-                <tr key={e.id}>
+                <tr key={e.id} className={match ? 'table-success' : ''}>
                   <td>{e.chassis}</td>
                   <td>{g?.version || '-'}</td>
                   <td>{e.hostname}</td>
@@ -143,29 +110,6 @@ export default function Software({ role }: { role: string }) {
             })}
           </tbody>
         </table>
-      </div>
-      <div className="offcanvas offcanvas-end" tabIndex={-1} id="uploadGolden">
-        <div className="offcanvas-header">
-          <h5 className="offcanvas-title">Subir Golden - {currentModel}</h5>
-          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-        </div>
-        <div className="offcanvas-body">
-          <form onSubmit={handleUpload}>
-            <div className="mb-2">
-              <input
-                className="form-control"
-                value={version}
-                onChange={e => setVersion(e.target.value)}
-                placeholder="Versión"
-                required
-              />
-            </div>
-            <div className="mb-2">
-              <input className="form-control" type="file" onChange={e => setFile(e.target.files?.[0] || null)} required />
-            </div>
-            <button className="btn btn-primary" type="submit">Guardar</button>
-          </form>
-        </div>
       </div>
       <div className="offcanvas offcanvas-end" tabIndex={-1} id="scheduleJob">
         <div className="offcanvas-header">
@@ -201,3 +145,4 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
     return { redirect: { destination: '/', permanent: false } };
   }
 };
+

--- a/pages/software/golden.tsx
+++ b/pages/software/golden.tsx
@@ -1,0 +1,140 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+interface Equipment {
+  id: number;
+  chassis: string;
+}
+
+interface GoldenImage {
+  id: number;
+  model: string;
+  version: string;
+  filename: string;
+}
+
+export default function Golden({ role }: { role: string }) {
+  const [equipos, setEquipos] = useState<Equipment[]>([]);
+  const [golden, setGolden] = useState<GoldenImage[]>([]);
+  const [currentModel, setCurrentModel] = useState('');
+  const [version, setVersion] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  const fetchData = async () => {
+    const eq = await fetch('/api/equipos').then(r => r.json());
+    const gi = await fetch('/api/golden').then(r => r.json());
+    setEquipos(eq);
+    setGolden(gi);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const models = Array.from(new Set(equipos.map(e => e.chassis)));
+
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const buf = await file.arrayBuffer();
+    const base64 = Buffer.from(buf).toString('base64');
+    await fetch('/api/golden', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: currentModel, version, filename: file.name, file: base64 }),
+    });
+    setVersion('');
+    setFile(null);
+    fetchData();
+  };
+
+  const countByModel = (model: string) => equipos.filter(e => e.chassis === model).length;
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Golden Images</h2>
+        <div className="d-flex flex-wrap gap-2 mb-3">
+          {models.map(m => (
+            <div key={m}>
+              <span className="me-2">{m}</span>
+              <button
+                className="btn btn-sm btn-secondary"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#uploadGolden"
+                onClick={() => setCurrentModel(m)}
+              >
+                Subir golden image
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="card">
+          <div className="card-body">
+            <table className="table table-striped">
+              <thead>
+                <tr>
+                  <th>Modelo</th>
+                  <th>Versión</th>
+                  <th>Archivo</th>
+                  <th>Equipos</th>
+                </tr>
+              </thead>
+              <tbody>
+                {golden.map(g => (
+                  <tr key={g.id}>
+                    <td>{g.model}</td>
+                    <td>{g.version}</td>
+                    <td>{g.filename}</td>
+                    <td>{countByModel(g.model)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div className="offcanvas offcanvas-end" tabIndex={-1} id="uploadGolden">
+        <div className="offcanvas-header">
+          <h5 className="offcanvas-title">Subir Golden - {currentModel}</h5>
+          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div className="offcanvas-body">
+          <form onSubmit={handleUpload}>
+            <div className="mb-2">
+              <input
+                className="form-control"
+                value={version}
+                onChange={e => setVersion(e.target.value)}
+                placeholder="Versión"
+                required
+              />
+            </div>
+            <div className="mb-2">
+              <input className="form-control" type="file" onChange={e => setFile(e.target.files?.[0] || null)} required />
+            </div>
+            <button className="btn btn-primary" type="submit">Guardar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};
+


### PR DESCRIPTION
## Summary
- add Gestion de software menu with links for Golden Image and Actualizaciones
- implement Golden Images page with device counts and upload workflow
- split updates view into new Actualizaciones page with schedule option

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: missing @types/react yarn issue)*
- `npm run build` *(fails: missing @types/react yarn issue)*

------
https://chatgpt.com/codex/tasks/task_e_68a29712e9848322a2ced580eb724808