### PR TITLE
feat: add client/service and diagnostic modules

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,6 +9,7 @@ export default function Sidebar({ role }: SidebarProps) {
   const [showAdmin, setShowAdmin] = useState(false);
   const [showInventory, setShowInventory] = useState(false);
   const [showSoftware, setShowSoftware] = useState(false);
+  const [showClients, setShowClients] = useState(false);
 
   const handleLogout = async () => {
     await fetch('/api/logout');
@@ -103,6 +104,35 @@ export default function Sidebar({ role }: SidebarProps) {
             )}
           </li>
         )}
+
+        <li className="nav-item mt-3">
+          <button
+            className="nav-link text-start w-100 bg-transparent border-0 text-white"
+            onClick={() => setShowClients(!showClients)}
+          >
+            Clientes y Servicios
+          </button>
+          {showClients && (
+            <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+              <li>
+                <Link href="/clientes" className="nav-link link-light ms-3">
+                  Clientes
+                </Link>
+              </li>
+              <li>
+                <Link href="/servicios" className="nav-link link-light ms-3">
+                  Servicios
+                </Link>
+              </li>
+            </ul>
+          )}
+        </li>
+
+        <li className="nav-item mt-3">
+          <Link href="/diagnostico" className="nav-link link-light">
+            Diagnóstico
+          </Link>
+        </li>
       </ul>
       <hr className="border-secondary" />
       <button className="btn btn-danger w-100 mt-auto" onClick={handleLogout}>

--- a/pages/api/clients.ts
+++ b/pages/api/clients.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const clients = await prisma.client.findMany({ include: { services: true } });
+    return res.status(200).json(clients);
+  }
+
+  if (req.method === 'POST') {
+    const { name, contact } = req.body;
+    if (!name) return res.status(400).json({ message: 'Missing name' });
+    const client = await prisma.client.create({ data: { name, contact } });
+    return res.status(201).json(client);
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).end('Method Not Allowed');
+}
+

--- a/pages/api/diagnostic.ts
+++ b/pages/api/diagnostic.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { NodeSSH } from 'node-ssh';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { equipmentId, action } = req.body;
+  const eq = await prisma.equipment.findUnique({
+    where: { id: Number(equipmentId) },
+    include: { credential: true },
+  });
+  if (!eq || !eq.credential) return res.status(404).json({ message: 'Equipment not found' });
+
+  const ssh = new NodeSSH();
+  try {
+    await ssh.connect({ host: eq.ip, username: eq.credential.username, password: eq.credential.password });
+    let command = '';
+    switch (action) {
+      case 'port':
+        command = '/interface ethernet print';
+        break;
+      case 'communication':
+        command = 'ping 8.8.8.8 count=4';
+        break;
+      case 'cpu':
+        command = '/system resource print';
+        break;
+      case 'memory':
+        command = '/system resource print';
+        break;
+      case 'logs':
+        command = '/log print without-paging';
+        break;
+      default:
+        return res.status(400).json({ message: 'Unknown action' });
+    }
+    const result = await ssh.execCommand(command);
+    return res.status(200).json({ output: result.stdout });
+  } catch {
+    return res.status(500).json({ message: 'SSH connection failed' });
+  } finally {
+    ssh.dispose();
+  }
+}
+

--- a/pages/api/equipos/index.ts
+++ b/pages/api/equipos/index.ts
@@ -43,6 +43,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         type === 'Mikrotik'
           ? parseLine(stdout, 'upgrade-firmware:')
           : parseCiscoVersion(stdout);
+      const model = await prisma.model.upsert({
+        where: { name: chassis },
+        update: {},
+        create: { name: chassis },
+      });
       let hostname = '';
       if (type === 'Mikrotik') {
         const ident = (await ssh.execCommand('/system identity print')).stdout;
@@ -61,6 +66,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           type,
           siteId,
           credentialId,
+          modelId: model.id,
         },
       });
       try {

--- a/pages/api/services.ts
+++ b/pages/api/services.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+
+function baseTemplate(name: string) {
+  return [
+    `/system identity set name="${name}"`,
+    `/ip service set telnet disabled`,
+    `/ip service set ftp disabled`,
+    `/ip service set www disabled`,
+    `/ip service set ssh address=0.0.0.0/0`,
+  ].join('\n');
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method === 'GET') {
+    const services = await prisma.service.findMany({ include: { client: true, equipment: true } });
+    return res.status(200).json(services);
+  }
+
+  if (req.method === 'POST') {
+    const { clientId, type, equipmentId, port, deviceModel } = req.body;
+    if (!clientId || !type) return res.status(400).json({ message: 'Missing fields' });
+
+    const client = await prisma.client.findUnique({ where: { id: Number(clientId) } });
+    if (!client) return res.status(404).json({ message: 'Client not found' });
+
+    const data: any = {
+      clientId: Number(clientId),
+      type,
+      config: baseTemplate(client.name),
+    };
+
+    if (type === 'CAPA2') {
+      if (!equipmentId || !port) return res.status(400).json({ message: 'Missing equipment or port' });
+      data.equipmentId = Number(equipmentId);
+      data.port = port;
+    } else if (type === 'GESTIONADO') {
+      if (!deviceModel) return res.status(400).json({ message: 'Missing device model' });
+      data.deviceModel = deviceModel;
+    }
+
+    const service = await prisma.service.create({ data });
+    return res.status(201).json(service);
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  return res.status(405).end('Method Not Allowed');
+}
+

--- a/pages/clientes.tsx
+++ b/pages/clientes.tsx
@@ -1,0 +1,114 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../components/Sidebar';
+
+interface Client {
+  id: number;
+  name: string;
+  contact?: string;
+}
+
+export default function Clientes({ role }: { role: string }) {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [form, setForm] = useState({ name: '', contact: '' });
+
+  const fetchClients = async () => {
+    const res = await fetch('/api/clients');
+    const data = await res.json();
+    setClients(data);
+  };
+
+  useEffect(() => {
+    fetchClients();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/clients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    setForm({ name: '', contact: '' });
+    fetchClients();
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Clientes</h2>
+        <button className="btn btn-primary mb-2" data-bs-toggle="offcanvas" data-bs-target="#addClient">
+          Agregar cliente
+        </button>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Nombre</th>
+              <th>Contacto</th>
+            </tr>
+          </thead>
+          <tbody>
+            {clients.map(c => (
+              <tr key={c.id}>
+                <td>{c.name}</td>
+                <td>{c.contact}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="offcanvas offcanvas-end" tabIndex={-1} id="addClient">
+        <div className="offcanvas-header">
+          <h5 className="offcanvas-title">Nuevo cliente</h5>
+          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div className="offcanvas-body">
+          <form onSubmit={handleAdd}>
+            <div className="mb-2">
+              <input
+                className="form-control"
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                placeholder="Nombre"
+                required
+              />
+            </div>
+            <div className="mb-2">
+              <input
+                className="form-control"
+                name="contact"
+                value={form.contact}
+                onChange={handleChange}
+                placeholder="Contacto"
+              />
+            </div>
+            <button className="btn btn-primary" type="submit">
+              Guardar
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};
+

--- a/pages/diagnostico.tsx
+++ b/pages/diagnostico.tsx
@@ -1,0 +1,80 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../components/Sidebar';
+
+interface Equipment { id: number; hostname: string }
+
+export default function Diagnostico({ role }: { role: string }) {
+  const [equipos, setEquipos] = useState<Equipment[]>([]);
+  const [equipmentId, setEquipmentId] = useState('');
+  const [action, setAction] = useState('port');
+  const [output, setOutput] = useState('');
+
+  useEffect(() => {
+    fetch('/api/equipos')
+      .then(r => r.json())
+      .then(setEquipos);
+  }, []);
+
+  const handleRun = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/diagnostic', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ equipmentId, action }),
+    });
+    const data = await res.json();
+    setOutput(data.output || data.message);
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Diagnóstico</h2>
+        <form onSubmit={handleRun} className="mb-3">
+          <div className="row g-2 align-items-end">
+            <div className="col">
+              <select className="form-select" value={equipmentId} onChange={e => setEquipmentId(e.target.value)} required>
+                <option value="">Seleccione equipo</option>
+                {equipos.map(e => (
+                  <option key={e.id} value={e.id}>
+                    {e.hostname}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="col">
+              <select className="form-select" value={action} onChange={e => setAction(e.target.value)}>
+                <option value="port">Estado de puertos</option>
+                <option value="communication">Ver comunicación</option>
+                <option value="cpu">Ver CPU</option>
+                <option value="memory">Ver memoria</option>
+                <option value="logs">Ver logs</option>
+              </select>
+            </div>
+            <div className="col-auto">
+              <button className="btn btn-primary" type="submit">
+                Ejecutar
+              </button>
+            </div>
+          </div>
+        </form>
+        <pre className="bg-light p-3" style={{ whiteSpace: 'pre-wrap' }}>{output}</pre>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};

--- a/pages/servicios.tsx
+++ b/pages/servicios.tsx
@@ -1,0 +1,179 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useEffect, useState } from 'react';
+import Sidebar from '../components/Sidebar';
+
+interface Client { id: number; name: string }
+interface Equipment { id: number; hostname: string }
+interface Service {
+  id: number;
+  type: string;
+  client: Client;
+  equipment?: Equipment;
+  port?: string;
+  deviceModel?: string;
+}
+
+const managedDevices = [
+  'hAP lite (RB941-2nD)',
+  'hAP ac²',
+  'hAP ac³',
+  'RB750Gr3 (hEX)',
+  'RB760iGS (hEX S)',
+  'hAP ax²',
+  'CSS106-5G-1S',
+  'CRS106-1C-5S',
+  'CRS112-8P-4S-IN',
+  'CRS305-1G-4S+IN',
+  'CRS328-4C-20S-4S+RM',
+];
+
+export default function Servicios({ role }: { role: string }) {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [equipos, setEquipos] = useState<Equipment[]>([]);
+  const [services, setServices] = useState<Service[]>([]);
+  const [form, setForm] = useState({ clientId: '', type: 'CAPA2', equipmentId: '', port: '', deviceModel: '' });
+
+  const fetchAll = async () => {
+    const [cl, eq, sv] = await Promise.all([
+      fetch('/api/clients').then(r => r.json()),
+      fetch('/api/equipos').then(r => r.json()),
+      fetch('/api/services').then(r => r.json()),
+    ]);
+    setClients(cl);
+    setEquipos(eq);
+    setServices(sv);
+  };
+
+  useEffect(() => {
+    fetchAll();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/services', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    setForm({ clientId: '', type: 'CAPA2', equipmentId: '', port: '', deviceModel: '' });
+    fetchAll();
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Servicios</h2>
+        <button className="btn btn-primary mb-2" data-bs-toggle="offcanvas" data-bs-target="#addService">
+          Agregar servicio
+        </button>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Cliente</th>
+              <th>Tipo</th>
+              <th>Detalle</th>
+            </tr>
+          </thead>
+          <tbody>
+            {services.map(s => (
+              <tr key={s.id}>
+                <td>{s.client.name}</td>
+                <td>{s.type}</td>
+                <td>
+                  {s.type === 'CAPA2'
+                    ? `${s.equipment?.hostname || ''} - ${s.port}`
+                    : s.deviceModel}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="offcanvas offcanvas-end" tabIndex={-1} id="addService">
+        <div className="offcanvas-header">
+          <h5 className="offcanvas-title">Nuevo servicio</h5>
+          <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div className="offcanvas-body">
+          <form onSubmit={handleAdd}>
+            <div className="mb-2">
+              <select className="form-select" name="clientId" value={form.clientId} onChange={handleChange} required>
+                <option value="">Seleccione cliente</option>
+                {clients.map(c => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mb-2">
+              <select className="form-select" name="type" value={form.type} onChange={handleChange}>
+                <option value="CAPA2">Servicio Capa 2</option>
+                <option value="GESTIONADO">Servicio Gestionado</option>
+              </select>
+            </div>
+            {form.type === 'CAPA2' && (
+              <>
+                <div className="mb-2">
+                  <select className="form-select" name="equipmentId" value={form.equipmentId} onChange={handleChange} required>
+                    <option value="">Seleccione equipo</option>
+                    {equipos.map(e => (
+                      <option key={e.id} value={e.id}>
+                        {e.hostname}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mb-2">
+                  <input
+                    className="form-control"
+                    name="port"
+                    value={form.port}
+                    onChange={handleChange}
+                    placeholder="Puerto"
+                    required
+                  />
+                </div>
+              </>
+            )}
+            {form.type === 'GESTIONADO' && (
+              <div className="mb-2">
+                <select className="form-select" name="deviceModel" value={form.deviceModel} onChange={handleChange} required>
+                  <option value="">Seleccione modelo</option>
+                  {managedDevices.map(m => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <button className="btn btn-primary" type="submit">
+              Guardar
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,18 +51,21 @@ model Equipment {
   siteId       Int?
   credential   Credential? @relation(fields: [credentialId], references: [id])
   credentialId Int?
+  model        Model?      @relation(fields: [modelId], references: [id])
+  modelId      Int?
   jobs         Job[]
 }
 
 model Backup {
-  id         Int      @id @default(autoincrement())
+  id         Int        @id @default(autoincrement())
   deviceId   Int
+  equipment  Equipment  @relation(fields: [deviceId], references: [id])
   exportPath String
   exportHash String
   binaryPath String?
   binaryHash String?
   diffPath   String?
-  createdAt  DateTime @default(now())
+  createdAt  DateTime   @default(now())
 }
 
 model Job {
@@ -79,11 +82,44 @@ model Job {
 }
 
 model GoldenImage {
-  id        Int      @id @default(autoincrement())
-  model     String   @unique
-  version   String
-  filename  String
-  sha256    String
-  uploadedAt DateTime @default(now())
-  jobs      Job[]
+  id         Int       @id @default(autoincrement())
+  model      String    @unique
+  version    String
+  filename   String
+  sha256     String
+  uploadedAt DateTime  @default(now())
+  jobs       Job[]
+  models     Model[]
+}
+
+model Model {
+  id            Int          @id @default(autoincrement())
+  name          String       @unique
+  goldenImage   GoldenImage? @relation(fields: [goldenImageId], references: [id])
+  goldenImageId Int?
+  equipments    Equipment[]
+}
+
+enum ServiceType {
+  CAPA2
+  GESTIONADO
+}
+
+model Client {
+  id       Int       @id @default(autoincrement())
+  name     String
+  contact  String?
+  services Service[]
+}
+
+model Service {
+  id          Int         @id @default(autoincrement())
+  type        ServiceType
+  client      Client      @relation(fields: [clientId], references: [id])
+  clientId    Int
+  equipment   Equipment?  @relation(fields: [equipmentId], references: [id])
+  equipmentId Int?
+  port        String?
+  deviceModel String?
+  config      String?
 }

--- a/run
+++ b/run
@@ -1,0 +1,23 @@
+# Pasos para ejecutar la aplicación
+
+1. Instalar dependencias:
+
+```bash
+npm install
+```
+
+2. Ejecutar las migraciones y generar el cliente de Prisma:
+
+```bash
+npx prisma generate
+npx prisma migrate deploy
+```
+
+3. Iniciar el entorno de desarrollo:
+
+```bash
+npm run dev
+```
+
+La aplicación estará disponible en http://localhost:3000
+


### PR DESCRIPTION
## Summary
- add run instructions for installing and running the app
- extend database schema with model relations, clients, services, and new enums
- implement clients/services management UI and diagnostic SSH page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to install required TypeScript dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68c704bc4b80833194b8588e271a2edf