### PR TITLE
Add node role handling and client tracing tools

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ export default function Sidebar({ role }: SidebarProps) {
   const [showInventory, setShowInventory] = useState(false);
   const [showSoftware, setShowSoftware] = useState(false);
   const [showClients, setShowClients] = useState(false);
+  const [showOperation, setShowOperation] = useState(false);
 
   const handleLogout = async () => {
     await fetch('/api/logout');
@@ -134,9 +135,26 @@ export default function Sidebar({ role }: SidebarProps) {
         </li>
 
         <li className="nav-item mt-3">
-          <Link href="/diagnostico" className="nav-link link-light">
-            Diagnóstico
-          </Link>
+          <button
+            className="nav-link text-start w-100 bg-transparent border-0 text-white"
+            onClick={() => setShowOperation(!showOperation)}
+          >
+            Operación
+          </button>
+          {showOperation && (
+            <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+              <li>
+                <Link href="/diagnostico" className="nav-link link-light ms-3">
+                  Diagnóstico
+                </Link>
+              </li>
+              <li>
+                <Link href="/operacion/rastreo-clientes" className="nav-link link-light ms-3">
+                  Rastreo de clientes
+                </Link>
+              </li>
+            </ul>
+          )}
         </li>
       </ul>
       <hr className="border-secondary" />

--- a/pages/api/equipos/[id].ts
+++ b/pages/api/equipos/[id].ts
@@ -25,10 +25,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (method === 'PUT') {
-    const { ip, credentialId, siteId, type, hostname } = req.body;
+    const { ip, credentialId, siteId, type, hostname, networkRole } = req.body;
     const eq = await prisma.equipment.update({
       where: { id: eqId },
-      data: { ip, credentialId, siteId, type, hostname },
+      data: {
+        ip,
+        credentialId,
+        siteId,
+        type,
+        hostname,
+        networkRole: networkRole === 'Cliente' ? 'Cliente' : 'Nodo',
+      },
     });
     return res.status(200).json(eq);
   }

--- a/pages/api/equipos/index.ts
+++ b/pages/api/equipos/index.ts
@@ -21,12 +21,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'POST') {
-    const { ip, credentialId, siteId, type } = req.body;
+    const { ip, credentialId, siteId, type, networkRole } = req.body;
     const cred = await prisma.credential.findUnique({ where: { id: credentialId } });
     if (!cred) return res.status(400).json({ message: 'Credential not found' });
 
     const existing = await prisma.equipment.findFirst({ where: { ip } });
     if (existing) return res.status(409).json({ message: 'Equipment already exists' });
+
+    const role = networkRole === 'Cliente' ? 'Cliente' : 'Nodo';
 
     const ssh = new NodeSSH();
     try {
@@ -69,6 +71,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           siteId,
           credentialId,
           modelId: model.id,
+          networkRole: role,
         },
       });
       if (portsData.length) {
@@ -113,70 +116,29 @@ function parseCiscoVersion(output: string) {
 }
 
 async function getMikrotikPorts(ssh: NodeSSH) {
-  const detailOutput = (await ssh.execCommand('/interface ethernet print detail without-paging')).stdout;
-  const physicalNames = parseMikrotikDefaultNames(detailOutput);
+  const command =
+    ':foreach i in=[/interface find] do={:put ( [/interface get $i name] . " - " . [/interface get $i default-name])}';
+  const { stdout } = await ssh.execCommand(command);
+  const lines = stdout.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
 
   const ports: { physicalName: string; description: string; status: string }[] = [];
 
-  for (const physicalName of physicalNames) {
-    if (!physicalName) continue;
+  for (const line of lines) {
+    const [firstSegment, ...rest] = line.split(' - ');
+    if (!firstSegment) continue;
 
-    let description = '';
-    try {
-      const command = `/interface ethernet print without-paging where default-name="${physicalName.replace(/"/g, '""')}"`;
-      const { stdout } = await ssh.execCommand(command);
-      description = parseMikrotikInterfaceName(stdout);
-    } catch (error) {
-      description = '';
-    }
-
-    const finalDescription = description || physicalName;
+    const physicalName = firstSegment.trim();
+    const descriptionRaw = rest.length ? rest.join(' - ').trim() : '';
+    const description = descriptionRaw || physicalName;
+    const comparisonA = physicalName.trim();
+    const comparisonB = descriptionRaw.trim();
     const status =
-      physicalName.localeCompare(finalDescription, undefined, { sensitivity: 'accent' }) === 0 ? 'Puerto Libre' : 'Asignado';
-    ports.push({ physicalName, description: finalDescription, status });
+      comparisonA && comparisonA.localeCompare(comparisonB, undefined, { sensitivity: 'base' }) === 0
+        ? 'Puerto Libre'
+        : 'Asignado';
+
+    ports.push({ physicalName, description, status });
   }
 
   return ports;
-}
-
-function parseMikrotikDefaultNames(output: string) {
-  const matches = output.matchAll(/default-name=(["'][^"']*["']|\S+)/gi);
-  const names: string[] = [];
-
-  for (const match of matches) {
-    const physicalName = stripQuotes(match[1]);
-    if (physicalName && !names.includes(physicalName)) {
-      names.push(physicalName);
-    }
-  }
-
-  return names;
-}
-
-function parseMikrotikInterfaceName(output: string) {
-  if (!output) return '';
-  const lines = output.split(/\r?\n/);
-  const dataLine = lines.find(line => /^\s*\d+/.test(line));
-  if (!dataLine) return '';
-
-  const headerLine = lines.find(line => /\bNAME\b/i.test(line) && /\bMTU\b/i.test(line));
-  if (headerLine) {
-    const nameStart = headerLine.indexOf('NAME');
-    const mtuStart = headerLine.indexOf('MTU');
-    if (nameStart >= 0) {
-      const raw = dataLine.slice(nameStart, mtuStart > nameStart ? mtuStart : undefined).trim();
-      if (raw) return raw;
-    }
-  }
-
-  const tokens = dataLine.trim().split(/\s+/);
-  return tokens.length >= 3 ? tokens[2] : '';
-}
-
-function stripQuotes(value: string | undefined) {
-  if (!value) return '';
-  if (/^(['"]).*\1$/.test(value)) {
-    return value.slice(1, -1);
-  }
-  return value;
 }

--- a/pages/api/operation/client-trace.ts
+++ b/pages/api/operation/client-trace.ts
@@ -1,0 +1,104 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../lib/prisma';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { NodeSSH } from 'node-ssh';
+
+interface TraceResult {
+  equipmentId: number;
+  hostname: string;
+  ip: string;
+  success: boolean;
+  output: string;
+}
+
+function normalizeMac(mac: unknown) {
+  const raw = typeof mac === 'string' ? mac.trim() : '';
+  if (!raw) return '';
+
+  const standardized = raw.replace(/-/g, ':');
+  if (/^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/.test(standardized)) {
+    return standardized.toUpperCase();
+  }
+
+  const stripped = raw.replace(/[^0-9A-Fa-f]/g, '');
+  if (stripped.length === 12) {
+    const pairs = stripped.match(/.{1,2}/g);
+    return pairs ? pairs.join(':').toUpperCase() : '';
+  }
+
+  return '';
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const mac = normalizeMac(req.body?.mac);
+  if (!mac) {
+    return res.status(400).json({ message: 'Ingrese una dirección MAC válida.' });
+  }
+
+  const nodes = await prisma.equipment.findMany({
+    where: { networkRole: 'Nodo' },
+    include: { credential: true },
+    orderBy: { hostname: 'asc' },
+  });
+
+  if (nodes.length === 0) {
+    return res.status(200).json({ message: 'No hay nodos registrados para realizar el rastreo.', results: [], mac });
+  }
+
+  const results: TraceResult[] = [];
+
+  for (const node of nodes) {
+    if (!node.credential) {
+      results.push({
+        equipmentId: node.id,
+        hostname: node.hostname,
+        ip: node.ip,
+        success: false,
+        output: 'El nodo no tiene una credencial asociada.',
+      });
+      continue;
+    }
+
+    const ssh = new NodeSSH();
+    try {
+      await ssh.connect({ host: node.ip, username: node.credential.username, password: node.credential.password });
+      const command = `/interface bridge host print where mac-address=${mac}`;
+      const execResult = await ssh.execCommand(command);
+      const rawOutput = [execResult.stdout, execResult.stderr].filter(Boolean).join('\n').trim();
+      results.push({
+        equipmentId: node.id,
+        hostname: node.hostname,
+        ip: node.ip,
+        success: true,
+        output: rawOutput || 'Sin coincidencias para la MAC especificada.',
+      });
+    } catch (error) {
+      results.push({
+        equipmentId: node.id,
+        hostname: node.hostname,
+        ip: node.ip,
+        success: false,
+        output: 'No se pudo ejecutar el comando en este nodo.',
+      });
+    } finally {
+      ssh.dispose();
+    }
+  }
+
+  return res.status(200).json({ results, mac });
+}
+

--- a/pages/equipos/index.tsx
+++ b/pages/equipos/index.tsx
@@ -13,6 +13,7 @@ interface Equipment {
   serial: string;
   version: string;
   type: string;
+  networkRole: string;
   site?: { nombre: string } | null;
 }
 
@@ -32,6 +33,7 @@ export default function Equipos({ role }: { role: string }) {
   const [credentialId, setCredentialId] = useState('');
   const [siteId, setSiteId] = useState('');
   const [type, setType] = useState('Mikrotik');
+  const [networkRole, setNetworkRole] = useState('Nodo');
   const [search, setSearch] = useState('');
   const [credentials, setCredentials] = useState<Credential[]>([]);
   const [sites, setSites] = useState<SiteOption[]>([]);
@@ -57,7 +59,13 @@ export default function Equipos({ role }: { role: string }) {
       const res = await fetch('/api/equipos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ip, credentialId: Number(credentialId), siteId: siteId ? Number(siteId) : null, type }),
+        body: JSON.stringify({
+          ip,
+          credentialId: Number(credentialId),
+          siteId: siteId ? Number(siteId) : null,
+          type,
+          networkRole,
+        }),
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
@@ -67,6 +75,7 @@ export default function Equipos({ role }: { role: string }) {
         setCredentialId('');
         setSiteId('');
         setType('Mikrotik');
+        setNetworkRole('Nodo');
         fetchEquipos();
       } else if (res.status === 409) {
         setAlertMsg({ type: 'warning', message: 'El equipo ya se encuentra en la base de datos' });
@@ -113,6 +122,7 @@ export default function Equipos({ role }: { role: string }) {
               <th>Serial</th>
               <th>Versión</th>
               <th>Tipo</th>
+              <th>Rol</th>
               <th>Sitio</th>
               <th>Acciones</th>
             </tr>
@@ -126,6 +136,7 @@ export default function Equipos({ role }: { role: string }) {
                 <td>{e.serial}</td>
                 <td>{e.version}</td>
                 <td>{e.type}</td>
+                <td>{e.networkRole}</td>
                 <td>{e.site?.nombre || ''}</td>
                 <td>
                   <button className="btn btn-sm btn-danger" onClick={() => handleDelete(e.id)}>
@@ -167,6 +178,12 @@ export default function Equipos({ role }: { role: string }) {
               <select className="form-select" value={type} onChange={e => setType(e.target.value)}>
                 <option value="Cisco">Cisco</option>
                 <option value="Mikrotik">Mikrotik</option>
+              </select>
+            </div>
+            <div className="mb-3">
+              <select className="form-select" value={networkRole} onChange={e => setNetworkRole(e.target.value)}>
+                <option value="Nodo">Nodo</option>
+                <option value="Cliente">Cliente</option>
               </select>
             </div>
             <button className="btn btn-primary" type="submit">Guardar</button>

--- a/pages/operacion/rastreo-clientes.tsx
+++ b/pages/operacion/rastreo-clientes.tsx
@@ -1,0 +1,133 @@
+import { GetServerSideProps } from 'next';
+import { parse } from 'cookie';
+import jwt from 'jsonwebtoken';
+import { useState } from 'react';
+import Sidebar from '../../components/Sidebar';
+
+interface TraceResult {
+  equipmentId: number;
+  hostname: string;
+  ip: string;
+  success: boolean;
+  output: string;
+}
+
+export default function RastreoClientes({ role }: { role: string }) {
+  const [mac, setMac] = useState('');
+  const [results, setResults] = useState<TraceResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [info, setInfo] = useState('');
+  const [searchedMac, setSearchedMac] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setInfo('');
+    setResults([]);
+    setSearchedMac('');
+
+    const requestedMac = mac.trim();
+    if (!requestedMac) {
+      setError('Indique una dirección MAC para realizar el rastreo.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch('/api/operation/client-trace', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mac: requestedMac }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.message || 'Error al realizar el rastreo.');
+        return;
+      }
+      setResults(data.results || []);
+      setSearchedMac(data.mac || requestedMac.toUpperCase());
+      if (data.message) {
+        setInfo(data.message);
+      } else if (!data.results || data.results.length === 0) {
+        setInfo('No se encontraron resultados en los nodos consultados.');
+      }
+    } catch (err) {
+      setError('No se pudo completar la solicitud.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="d-flex">
+      <Sidebar role={role} />
+      <div className="p-4 flex-grow-1">
+        <h2>Rastreo de clientes</h2>
+        <form onSubmit={handleSubmit} className="mb-3">
+          <div className="row g-2 align-items-end">
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="macInput">
+                Indicar MAC a buscar en los nodos
+              </label>
+              <input
+                id="macInput"
+                className="form-control"
+                value={mac}
+                onChange={e => setMac(e.target.value)}
+                placeholder="Ej. AA:BB:CC:DD:EE:FF"
+              />
+            </div>
+            <div className="col-auto">
+              <button className="btn btn-primary" type="submit" disabled={loading}>
+                {loading ? 'Buscando...' : 'Buscar'}
+              </button>
+            </div>
+          </div>
+        </form>
+        {loading && <div className="alert alert-info">Consultando nodos...</div>}
+        {error && <div className="alert alert-danger">{error}</div>}
+        {info && !error && <div className="alert alert-info">{info}</div>}
+        {searchedMac && results.length > 0 && (
+          <p className="text-muted">
+            Resultados para: <strong>{searchedMac}</strong>
+          </p>
+        )}
+        {results.map(result => (
+          <div className="card mb-3" key={result.equipmentId}>
+            <div className="card-header d-flex justify-content-between align-items-center">
+              <div>
+                <strong>{result.hostname || 'Nodo sin nombre'}</strong>
+                <div className="small text-muted">{result.ip}</div>
+              </div>
+              <span className={`badge ${result.success ? 'text-bg-success' : 'text-bg-danger'}`}>
+                {result.success ? 'Comando ejecutado' : 'Error'}
+              </span>
+            </div>
+            <div className="card-body">
+              {result.success ? (
+                <pre className="mb-0" style={{ whiteSpace: 'pre-wrap' }}>
+                  {result.output}
+                </pre>
+              ) : (
+                <p className="mb-0 text-danger">{result.output}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies.token || '';
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+    return { props: { role: payload.role } };
+  } catch {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+};
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Equipment {
   serial       String
   version      String
   type         String
+  networkRole  String      @default("Nodo")
   site         Site?       @relation(fields: [siteId], references: [id])
   siteId       Int?
   credential   Credential? @relation(fields: [credentialId], references: [id])


### PR DESCRIPTION
## Summary
- add a network role attribute to equipments so inventory captures whether a device es nodo o cliente
- adjust Mikrotik port collection to use the provided foreach command and derive the port status from the new output format
- expose an Operación menu with the existing diagnóstico view and a new rastreo de clientes workflow plus API to query MAC addresses across all nodos

## Testing
- npm run lint *(fails: registry denied installing @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a089c68883318dd32a7105277abe